### PR TITLE
Changing the pressure formula to barometric formula

### DIFF
--- a/src/pitot/isa.py
+++ b/src/pitot/isa.py
@@ -69,12 +69,12 @@ def pressure(h: Any) -> pint.Quantity[Any]:
     """
     temp = temperature(h)
     temp_0 = temperature(0)
-    dT = np.maximum(Q_(0, "m"), h - H_TROP)
+    delta = np.maximum(Q_(0, "m"), h - H_TROP)
 
     press: pint.Quantity[Any] = np.where(
         h < H_TROP,
         P_0 * (temp / temp_0) ** (-G_0 / (BETA_T * R)),
-        TROPOPAUSE_PRESS * np.exp(-G_0 / (R * STRATOSPHERE_TEMP) * dT),
+        TROPOPAUSE_PRESS * np.exp(-G_0 / (R * STRATOSPHERE_TEMP) * delta),
     )
     return press
 
@@ -100,7 +100,12 @@ def atmosphere(
     den: pint.Quantity[Any] = density_troposphere * np.exp(
         -delta / Q_(6341.5522, "m")
     )
-    press: pint.Quantity[Any] = den * temp * SPECIFIC_GAS_CONSTANT
+    temp_0 = temperature(0)
+    press: pint.Quantity[Any] = np.where(
+        h < H_TROP,
+        P_0 * (temp / temp_0) ** (-G_0 / (BETA_T * R)),
+        TROPOPAUSE_PRESS * np.exp(-G_0 / (R * STRATOSPHERE_TEMP) * delta),
+    )
     return press, den, temp
 
 

--- a/src/pitot/isa.pyi
+++ b/src/pitot/isa.pyi
@@ -22,6 +22,10 @@ R: pint.Quantity[float]
 RHO_0: pint.Quantity[float]
 SPECIFIC_GAS_CONSTANT: pint.Quantity[float]
 STRATOSPHERE_TEMP: pint.Quantity[float]
+G_0: pint.Quantity[float]
+BETA_T: pint.Quantity[float]
+TROPOPAUSE_PRESS: pint.Quantity[float]
+H_TROP: pint.Quantity[float]
 
 temperature: ISA_Method
 density: ISA_Method


### PR DESCRIPTION
I noticed some slight errors in pressure when calculated using the implemented perfect gas formula. So I changed it to the barometric formula (https://en.wikipedia.org/wiki/Barometric_formula) which seems to yield pressures closer to the ISA tables. Maybe those approximations were due to rounding in calculations.

What do you think?

